### PR TITLE
Fix damage calculation and potential memory leak

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -768,7 +768,7 @@
              {
                  int i = (this.func_70660_b(MobEffects.field_76429_m).func_76458_c() + 1) * 5;
                  int j = 25 - i;
-@@ -1376,24 +1558,154 @@
+@@ -1376,24 +1558,164 @@
          }
      }
  
@@ -824,7 +824,14 @@
 +            Function<Double, Double> armor = new Function<Double, Double>() {
 +                @Override
 +                public Double apply(Double f) {
-+                    return -(f - EntityLivingBase.this.func_70655_b(damagesource, f.floatValue()));
++                    // Mohist: calculating custom armor resist and default armor resist
++                    float specialArmorCalc = 0.0F;
++                    if (human && f > 0.0F) {
++                        specialArmorCalc = ISpecialArmor.ArmorProperties.applyArmor(EntityLivingBase.this, ((EntityPlayer) EntityLivingBase.this).field_71071_by.field_70460_b, damagesource, f);
++                    }
++                    float defaultArmorCalc = EntityLivingBase.this.func_70655_b(damagesource, f.floatValue());
++                    //return -(f - EntityLivingBase.this.applyArmorCalculations(damagesource, f.floatValue()));
++                    return -(f - Math.max(defaultArmorCalc, specialArmorCalc));
 +                }
 +            };
 +            float armorModifier = armor.apply((double) f).floatValue();
@@ -867,10 +874,13 @@
 +                return false;
              }
 +
++            // Mohist: moved in armor modifier calculation
++            /*
 +            if (human && event.getDamage() > 0) {
-+                float damage = ISpecialArmor.ArmorProperties.applyArmor(EntityLivingBase.this, ((EntityPlayer) EntityLivingBase.this).field_71071_by.field_70460_b, damagesource, event.getDamage());
++                float damage = ISpecialArmor.ArmorProperties.applyArmor(EntityLivingBase.this, ((EntityPlayer) EntityLivingBase.this).inventory.armorInventory, damagesource, event.getDamage());
 +                event.setDamage(damage);
 +            }
++            */
 +
 +            // Apply damage to helmet
 +            if ((damagesource == DamageSource.field_82728_o || damagesource == DamageSource.field_82729_p) && this.func_184582_a(EntityEquipmentSlot.HEAD) != null) {
@@ -937,7 +947,7 @@
      }
  
      public CombatTracker func_110142_aN()
-@@ -1447,6 +1759,11 @@
+@@ -1447,6 +1769,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -949,7 +959,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1570,6 +1887,7 @@
+@@ -1570,6 +1897,7 @@
          if (this.field_110155_d == null)
          {
              this.field_110155_d = new AttributeMap();
@@ -957,7 +967,7 @@
          }
  
          return this.field_110155_d;
-@@ -1694,7 +2012,7 @@
+@@ -1694,7 +2022,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -966,7 +976,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +2020,14 @@
+@@ -1702,14 +2030,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -983,7 +993,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,16 +2099,17 @@
+@@ -1781,16 +2109,17 @@
          }
  
          this.field_70160_al = true;
@@ -1003,7 +1013,7 @@
      }
  
      protected float func_189749_co()
-@@ -1807,9 +2126,9 @@
+@@ -1807,9 +2136,9 @@
                  if (!this.func_180799_ab() || this instanceof EntityPlayer && ((EntityPlayer)this).field_71075_bZ.field_75100_b)
                  {
                      if (this.func_184613_cA())
@@ -1015,7 +1025,7 @@
                              this.field_70143_R = 1.0F;
                          }
  
-@@ -1819,27 +2138,27 @@
+@@ -1819,27 +2148,27 @@
                          double d8 = Math.sqrt(this.field_70159_w * this.field_70159_w + this.field_70179_y * this.field_70179_y);
                          double d1 = vec3d.func_72433_c();
                          float f4 = MathHelper.func_76134_b(f);
@@ -1050,7 +1060,7 @@
                              this.field_70159_w += (vec3d.field_72450_a / d6 * d8 - this.field_70159_w) * 0.1D;
                              this.field_70179_y += (vec3d.field_72449_c / d6 * d8 - this.field_70179_y) * 0.1D;
                          }
-@@ -1850,21 +2169,22 @@
+@@ -1850,21 +2179,22 @@
                          this.func_70091_d(MoverType.SELF, this.field_70159_w, this.field_70181_x, this.field_70179_y);
  
                          if (this.field_70123_F && !this.field_70170_p.field_72995_K)
@@ -1079,7 +1089,7 @@
                          }
                      }
                      else
-@@ -1874,7 +2194,8 @@
+@@ -1874,7 +2204,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -1089,7 +1099,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +2215,8 @@
+@@ -1894,7 +2225,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -1099,7 +1109,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2376,7 @@
+@@ -2054,6 +2386,7 @@
  
      public void func_70071_h_()
      {
@@ -1107,7 +1117,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2419,9 @@
+@@ -2096,7 +2429,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -1117,7 +1127,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2304,7 +2629,6 @@
+@@ -2304,7 +2639,6 @@
          }
  
          this.field_70170_p.field_72984_F.func_76320_a("ai");
@@ -1125,7 +1135,7 @@
          if (this.func_70610_aX())
          {
              this.field_70703_bu = false;
-@@ -2385,7 +2709,8 @@
+@@ -2385,7 +2719,8 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
@@ -1135,7 +1145,7 @@
          }
      }
  
-@@ -2519,12 +2844,12 @@
+@@ -2519,12 +2854,12 @@
  
      public boolean func_70067_L()
      {
@@ -1150,7 +1160,7 @@
      }
  
      protected void func_70018_K()
-@@ -2575,6 +2900,40 @@
+@@ -2575,6 +2910,40 @@
          this.field_70752_e = true;
      }
  
@@ -1191,7 +1201,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2592,15 +2951,23 @@
+@@ -2592,15 +2961,23 @@
          if (this.func_184587_cr())
          {
              ItemStack itemstack = this.func_184586_b(this.func_184600_cs());
@@ -1216,7 +1226,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2985,10 @@
+@@ -2618,8 +2995,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -1228,7 +1238,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +3069,27 @@
+@@ -2700,7 +3079,27 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -1257,7 +1267,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +3113,8 @@
+@@ -2724,7 +3123,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -1267,7 +1277,7 @@
          }
  
          this.func_184602_cy();
-@@ -2808,11 +3198,14 @@
+@@ -2808,11 +3208,14 @@
  
              if (flag1)
              {
@@ -1287,7 +1297,7 @@
                  }
              }
          }
-@@ -2847,11 +3240,41 @@
+@@ -2847,11 +3250,41 @@
          }
      }
  
@@ -1329,7 +1339,7 @@
      public boolean func_190631_cK()
      {
          return true;
-@@ -2861,4 +3284,30 @@
+@@ -2861,4 +3294,30 @@
      public void func_191987_a(BlockPos p_191987_1_, boolean p_191987_2_)
      {
      }

--- a/patches/minecraft/net/minecraft/pathfinding/PathWorldListener.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathWorldListener.java.patch
@@ -1,0 +1,61 @@
+--- ../src-base/minecraft/net/minecraft/pathfinding/PathWorldListener.java
++++ ../src-work/minecraft/net/minecraft/pathfinding/PathWorldListener.java
+@@ -1,8 +1,10 @@
+ package net.minecraft.pathfinding;
+ 
+-import com.google.common.collect.Lists;
+-import java.util.List;
++import java.util.Iterator;
++import java.util.Set;
+ import javax.annotation.Nullable;
++
++import com.google.common.collect.Sets;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.EntityLiving;
+@@ -16,18 +18,32 @@
+ 
+ public class PathWorldListener implements IWorldEventListener
+ {
+-    private final List<PathNavigate> field_189519_a = Lists.<PathNavigate>newArrayList();
++    // Mohist: Replace ArrayList to ConcurrentHashSet. Fix potential memory leak. All mojang lines are commented out.
++    // P.S: The maximum number of objects that I saw was 160k, but there were only 1.5k entities (mobs, items) in the world
++    // P.S.S: Used ConcurrentHashSet because got ConcurrentModificationException when testing with HashSet.
++    //private final List<PathNavigate> navigations = Lists.<PathNavigate>newArrayList();
++    private final Set<PathNavigate> field_189519_a = Sets.newConcurrentHashSet();
+ 
+     public void func_184376_a(World p_184376_1_, BlockPos p_184376_2_, IBlockState p_184376_3_, IBlockState p_184376_4_, int p_184376_5_)
+     {
+         if (this.func_184378_a(p_184376_1_, p_184376_2_, p_184376_3_, p_184376_4_))
+         {
+-            int i = 0;
+-
+-            for (int j = this.field_189519_a.size(); i < j; ++i)
++            // Mohist: code start. All mojang lines are commented out.
++            //int i = 0;
++            //for (int j = this.navigations.size(); i < j; ++i)
++            Iterator<PathNavigate> iter = field_189519_a.iterator();
++            while (iter.hasNext())
+             {
+-                PathNavigate pathnavigate = this.field_189519_a.get(i);
++                //PathNavigate pathnavigate = this.navigations.get(i);
++                PathNavigate pathnavigate = iter.next();
+ 
++                // Mohist: Remove invalid path navigators
++                if (!pathnavigate.field_75515_a.valid) {
++                    iter.remove();
++                    continue;
++                }
++                // Mohist: code end.
++
+                 if (pathnavigate != null && !pathnavigate.func_188553_i())
+                 {
+                     Path path = pathnavigate.func_75505_d();
+@@ -48,6 +64,7 @@
+         }
+     }
+ 
++
+     protected boolean func_184378_a(World p_184378_1_, BlockPos p_184378_2_, IBlockState p_184378_3_, IBlockState p_184378_4_)
+     {
+         AxisAlignedBB axisalignedbb = p_184378_3_.func_185890_d(p_184378_1_, p_184378_2_);


### PR DESCRIPTION
Rewrote my old damage calculation fix. Now using bukkit event damage value.
Found potential memory leak. Don't know how to reproduce, but on my server 5 players takes over 6 gb RAM (G1 Old Generation) without fix.
I have heap dump, if you interested - ask me in discord.
I analyzed it and found that path navigators list doesn't always get empty after entity removed. In heap dump over 160k objects in list, but there were only 1.5k entities (mobs, items) in the world.
