### PR TITLE
Fix #1461

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
@@ -220,7 +220,7 @@ public final class CraftItemStack extends ItemStack {
             case ENDER_CHEST:
                 return new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem()));
             default:
-                return item.getItem() instanceof ItemBlock ? new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem())) : new CraftMetaItem(item.getTagCompound());
+                return new CraftMetaItem(item.getTagCompound());
         }
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50796872/123289040-62e06c00-d510-11eb-86c5-063347f6ceba.png)

Skills names and lores are now displayed.