### PR TITLE
[CVE-2021-44228] Fix RCE

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -53,6 +53,7 @@
             <AppenderRef ref="File" />
         </Logger>
         <Root level="all" >
+            <RegexFilter regex=".*\$\{[^}]*\}.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             <AppenderRef ref="TerminalConsole" level="INFO" />
             <AppenderRef ref="File" level="INFO" />
             <!-- Set FmlFile to TRACE/DEBUG if you require more logging -->


### PR DESCRIPTION
Porting RegexFilter from client-1.7.xml to mitigate CVE-2021-44228.

note: {nolookup} added in a79475a does not work in log4j-2.0-beta9.