### PR TITLE
Reimplement a config option to skip entity activation checks

### DIFF
--- a/src/main/java/com/mohistmc/configuration/MohistConfig.java
+++ b/src/main/java/com/mohistmc/configuration/MohistConfig.java
@@ -90,6 +90,7 @@ public class MohistConfig extends ConfigBase {
     public final BoolSetting RealTimeTicking = new BoolSetting(this, "mohist.realtimeticking", false);
     public final BoolSetting FailOnUnresolvedGameProfile = new BoolSetting(this, "mohist.fail-on-unresolved-gameprofile", true);
     public final IntSetting entityTickLimit = new IntSetting(this, "entity-tick-limit", 300); // by CraftDream
+    public final BoolSetting skipEntityActivationRange = new BoolSetting(this, "skip-entity-activation-range", false); // by SmylerMC
     public final StringSetting libraries_black_list = new StringSetting(this, "libraries_black_list", "aaaaa;bbbbbb");
     public final BoolSetting hideJoinModsList = new BoolSetting(this, "hidejoinmodslist", false);
     public final BoolSetting watchdog_spigot = new BoolSetting(this, "mohist.watchdog_spigot", true);

--- a/src/main/java/org/spigotmc/ActivationRange.java
+++ b/src/main/java/org/spigotmc/ActivationRange.java
@@ -1,6 +1,7 @@
 package org.spigotmc;
 
 import co.aikar.timings.MinecraftTimings;
+import com.mohistmc.configuration.MohistConfig;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLiving;
@@ -218,6 +219,10 @@ public class ActivationRange {
      * @return
      */
     public static boolean checkIfActive(Entity entity) {
+
+        // Let users disable this in cases where is does not play well with some mods
+        if (MohistConfig.instance.skipEntityActivationRange.getValue()) return true;
+
         // Never safe to skip fireworks or entities not yet added to chunk
         // PAIL: inChunk
         if (!entity.addedToChunk || entity instanceof EntityFireworkRocket) {
@@ -238,14 +243,14 @@ public class ActivationRange {
             }
             // Add a little performance juice to active entities. Skip 1/4 if not immune.
         } else if (!entity.defaultActivationState && entity.ticksExisted % 4 == 0 && !checkEntityImmunities(entity)) {
-            isActive = false;
+            return false;
         }
         int x = MathHelper.floor(entity.posX);
         int z = MathHelper.floor(entity.posZ);
         // Make sure not on edge of unloaded chunk
         Chunk chunk = entity.world.getChunkIfLoaded(x >> 4, z >> 4);
         if (isActive && !(chunk != null && chunk.areNeighborsLoaded(1))) {
-            isActive = false;
+            return false;
         }
         return isActive;
     }


### PR DESCRIPTION
Gives a workaround to #1650, which is troublesome for a lot of BuildTheEarth servers that would want to update to the latest versions to be safe from Log4shell. Also slightly optimizes the method that does the check.

The config option is `skip-entity-activation-range`, at the root of the Mohist config.