### PR TITLE
[1.18.x] Change name of file output generate by mohistJar task in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1255,7 +1255,7 @@ project(':forge') {
         archiveClassifier = 'server'
         archiveExtension = 'jar'
         archiveBaseName = 'mohist'
-        archiveVersion = "1.18.x-" + JenkinsNumber.info()
+        archiveVersion = "1.18.1-" + JenkinsNumber.info()
         destinationDirectory = file('build/libs')
 
         def CLASS_PATH = Util.getArtifacts(project, project.configurations.installer, false).values().collect{"libraries/${it.downloads.artifact.path}"} +


### PR DESCRIPTION
Now, mohistJar task is ready to be build in Jenkins.
@Mgazul If you can build installerJar and mohistJar task on jenkins, we can test 1.18 installer !