### PR TITLE
[1.16.5] fixed license violations

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -556,7 +556,7 @@
           float f1 = 0.0F;
           if (p_70097_2_ > 0.0F && this.func_184583_d(p_70097_1_)) {
              this.func_184590_k(p_70097_2_);
-@@ -955,22 +_,40 @@
+@@ -955,22 +_,39 @@
  
           this.field_70721_aZ = 1.5F;
           boolean flag1 = true;
@@ -577,9 +577,8 @@
              flag1 = false;
           } else {
 +            // CraftBukkit start
-+            if(!this.damageEntity0(p_70097_1_, p_70097_2_)){
-+               return false;
-+            }
++            this.damageEntity0(p_70097_1_, p_70097_2_);
++
 +            // CraftBukkit end
              this.field_110153_bc = p_70097_2_;
 -            this.field_70172_ad = 20;

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import javax.annotation.Nullable;

--- a/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EntityTeleportEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.entity.Entity;


### PR DESCRIPTION
When I was playing around, I got a build error when the task `checkLicenseCustomMain` task was ran, saying License Violations where found at these two files.

So I ran the `licenseFormat` task, to fix it.
Builds fine now.