### PR TITLE
[1.16.5] Bed block half is still being placed in protected areas.

### DIFF
--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -36,10 +36,10 @@
              if (blockstate == null) {
                 return ActionResultType.FAIL;
              } else if (!this.func_195941_b(blockitemusecontext, blockstate)) {
-@@ -64,14 +_,26 @@
-                   blockstate1 = this.func_219985_a(blockpos, world, itemstack, blockstate1);
-                   this.func_195943_a(blockpos, world, playerentity, itemstack, blockstate1);
-                   block.func_180633_a(world, blockpos, blockstate1, playerentity, itemstack);
+@@ -61,6 +_,18 @@
+                BlockState blockstate1 = world.func_180495_p(blockpos);
+                Block block = blockstate1.func_177230_c();
+                if (block == blockstate.func_177230_c()) {
 +                  // CraftBukkit start
 +                  if (cbblockstate != null && playerentity != null) {
 +                     org.bukkit.event.block.BlockPlaceEvent placeEvent = org.bukkit.craftbukkit.v1_16_R3.event.CraftEventFactory.callBlockPlaceEvent((ServerWorld) world, playerentity, blockitemusecontext.func_221531_n(), cbblockstate, blockpos.func_177958_n(), blockpos.func_177956_o(), blockpos.func_177952_p());
@@ -52,8 +52,10 @@
 +                     }
 +                  }
 +                  // CraftBukkit end
-                   if (playerentity instanceof ServerPlayerEntity) {
-                      CriteriaTriggers.field_193137_x.func_193173_a((ServerPlayerEntity)playerentity, blockpos, itemstack);
+                   blockstate1 = this.func_219985_a(blockpos, world, itemstack, blockstate1);
+                   this.func_195943_a(blockpos, world, playerentity, itemstack, blockstate1);
+                   block.func_180633_a(world, blockpos, blockstate1, playerentity, itemstack);
+@@ -69,9 +_,9 @@
                    }
                 }
  


### PR DESCRIPTION
This PR fixes #1806 

It's caused by the CraftBukkit blockPlaceEvent being fired AFTER the block.setPlacedBy is called, I moved the event before placing the block, So the additions placed down by that method, is not fired.