### PR TITLE
[1.16.5] Capabilities not being re-added on death.

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -334,7 +334,7 @@
        } else {
           compoundnbt1 = this.field_72412_k.func_237336_b_(p_72380_1_);
        }
-@@ -293,187 +_,314 @@
+@@ -293,187 +_,315 @@
     }
  
     protected void func_72391_b(ServerPlayerEntity p_72391_1_) {
@@ -784,6 +784,7 @@
 +       this.func_72354_b(serverplayerentity, worldserver1);
 +       this.func_187243_f(serverplayerentity);
 +       if (!p_232644_1_.field_71135_a.isDisconnected()) {
++           serverplayerentity.gatherCapsAndRevive(); // Mohist - Re-gather the invalidated capabilities, since we don't create a new ServerPlayerEntity.
 +           worldserver1.func_217433_d(serverplayerentity);
 +           this.addPlayer(serverplayerentity);
 +           this.playersByName.put(serverplayerentity.func_195047_I_().toLowerCase(java.util.Locale.ROOT), serverplayerentity); // Spigot

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -64,6 +64,11 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
         gatherCapabilities(() -> null);
     }
 
+    public final void gatherCapsAndRevive() {
+        gatherCapabilities();
+        reviveCaps();
+    }
+
     protected final void gatherCapabilities(@Nullable ICapabilityProvider parent)
     {
         gatherCapabilities(() -> parent);


### PR DESCRIPTION
fix #1925 and #1920

This was a cause of the changes done in version 891 where the respawn of the player was changed.

This happens because we keep the ServerPlayerEntity, but do call remove in the respawn method.
The remove method, then invalidates the caps.

But since we are keeping the actual object, and not creating a new one, gatherCapabilities are never called for the same object, re add the caps.
This along with marking the caps as valid, after invalidating them. 