### PR TITLE
[1.16.5] KubeJS recipe errors fixed.

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/BlastingRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/BlastingRecipe.java.patch
@@ -20,7 +20,7 @@
 +   // CraftBukkit start
 +   @Override
 +   public Recipe toBukkitRecipe() {
-+      CraftItemStack result = CraftItemStack.asCraftMirror(this.field_222143_e);
++      CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +      CraftBlastingRecipe recipe = new CraftBlastingRecipe(CraftNamespacedKey.fromMinecraft(this.field_222140_b), result, CraftRecipe.toBukkit(this.field_222142_d), this.field_222144_f, this.field_222145_g);
 +      recipe.setGroup(this.field_222141_c);
 +      return recipe;

--- a/patches/minecraft/net/minecraft/item/crafting/CampfireCookingRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/CampfireCookingRecipe.java.patch
@@ -20,7 +20,7 @@
 +   // CraftBukkit start
 +    @Override
 +    public Recipe toBukkitRecipe() {
-+      CraftItemStack result = CraftItemStack.asCraftMirror(this.field_222143_e);
++      CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +      CraftCampfireRecipe recipe = new CraftCampfireRecipe(CraftNamespacedKey.fromMinecraft(this.field_222140_b), result, CraftRecipe.toBukkit(this.field_222142_d), this.field_222144_f, this.field_222145_g);
 +      recipe.setGroup(this.field_222141_c);
 +      return recipe;

--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipe.java.patch
@@ -20,7 +20,7 @@
 +   // CraftBukkit start
 +    @Override
 +    public Recipe toBukkitRecipe() {
-+      CraftItemStack result = CraftItemStack.asCraftMirror(this.field_222143_e);
++      CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +      CraftFurnaceRecipe recipe = new CraftFurnaceRecipe(CraftNamespacedKey.fromMinecraft(this.field_222140_b), result, CraftRecipe.toBukkit(this.field_222142_d), this.field_222144_f, this.field_222145_g);
 +      recipe.setGroup(this.field_222141_c);
 +      return recipe;

--- a/patches/minecraft/net/minecraft/item/crafting/ShapedRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShapedRecipe.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/item/crafting/ShapedRecipe.java
 +++ b/net/minecraft/item/crafting/ShapedRecipe.java
-@@ -20,8 +_,25 @@
+@@ -20,8 +_,26 @@
  import net.minecraft.util.ResourceLocation;
  import net.minecraft.util.registry.Registry;
  import net.minecraft.world.World;
@@ -9,6 +9,7 @@
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftRecipe;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftShapedRecipe;
++import org.bukkit.craftbukkit.v1_16_R3.util.CraftNamespacedKey;
 +import org.bukkit.inventory.RecipeChoice;
 +
 +public class ShapedRecipe implements ICraftingRecipe, net.minecraftforge.common.crafting.IShapedRecipe<CraftingInventory> {
@@ -34,22 +35,22 @@
  
 +   // CraftBukkit start
 +   public org.bukkit.inventory.ShapedRecipe toBukkitRecipe() {
-+      CraftItemStack result = CraftItemStack.asCraftMirror(this.field_77575_e);
-+      CraftShapedRecipe recipe = new CraftShapedRecipe(result, this);
-+      recipe.setGroup(this.field_194137_e);
++      CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
++      CraftShapedRecipe craftRecipe = new CraftShapedRecipe(result, this);
++      craftRecipe.setGroup(this.field_194137_e);
 +      switch (this.field_77577_c) {
 +         case 1: {
 +            switch (this.field_77576_b) {
 +               case 1: {
-+                  recipe.shape("a");
++                  craftRecipe.shape("a");
 +                  break;
 +               }
 +               case 2: {
-+                  recipe.shape("ab");
++                  craftRecipe.shape("ab");
 +                  break;
 +               }
 +               case 3: {
-+                  recipe.shape("abc");
++                  craftRecipe.shape("abc");
 +                  break;
 +               }
 +            }
@@ -58,15 +59,15 @@
 +         case 2: {
 +            switch (this.field_77576_b) {
 +               case 1: {
-+                  recipe.shape("a", "b");
++                  craftRecipe.shape("a", "b");
 +                  break;
 +               }
 +               case 2: {
-+                  recipe.shape("ab", "cd");
++                  craftRecipe.shape("ab", "cd");
 +                  break;
 +               }
 +               case 3: {
-+                  recipe.shape("abc", "def");
++                  craftRecipe.shape("abc", "def");
 +                  break;
 +               }
 +            }
@@ -75,15 +76,15 @@
 +         case 3: {
 +            switch (this.field_77576_b) {
 +               case 1: {
-+                  recipe.shape("a", "b", "c");
++                  craftRecipe.shape("a", "b", "c");
 +                  break;
 +               }
 +               case 2: {
-+                  recipe.shape("ab", "cd", "ef");
++                  craftRecipe.shape("ab", "cd", "ef");
 +                  break;
 +               }
 +               case 3: {
-+                  recipe.shape("abc", "def", "ghi");
++                  craftRecipe.shape("abc", "def", "ghi");
 +                  break;
 +               }
 +            }
@@ -94,11 +95,11 @@
 +      for (Ingredient list : this.field_77574_d) {
 +         RecipeChoice choice = CraftRecipe.toBukkit(list);
 +         if (choice != null) {
-+            recipe.setIngredient(c, choice);
++            craftRecipe.setIngredient(c, choice);
 +         }
 +         c++;
 +      }
-+      return recipe;
++      return craftRecipe;
 +   }
 +   // CraftBukkit end
 +

--- a/patches/minecraft/net/minecraft/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShapelessRecipe.java.patch
@@ -35,7 +35,7 @@
 +   // CraftBukkit start
 +   @Override
 +   public org.bukkit.inventory.ShapelessRecipe toBukkitRecipe() {
-+      CraftItemStack result = CraftItemStack.asCraftMirror(this.field_77580_a);
++      CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +      CraftShapelessRecipe recipe = new CraftShapelessRecipe(result, this);
 +      recipe.setGroup(this.field_194138_c);
 +      for (Ingredient list : this.field_77579_b) {

--- a/patches/minecraft/net/minecraft/item/crafting/SmithingRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/SmithingRecipe.java.patch
@@ -20,7 +20,7 @@
 +   // CraftBukkit start
 +   @Override
 +   public Recipe toBukkitRecipe() {
-+      CraftItemStack result = CraftItemStack.asCraftMirror(this.field_234839_c_);
++      CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +      CraftSmithingRecipe recipe = new CraftSmithingRecipe(CraftNamespacedKey.fromMinecraft(this.field_234840_d_), result, CraftRecipe.toBukkit(this.field_234837_a_), CraftRecipe.toBukkit(this.field_234838_b_));
 +      return recipe;
 +   }

--- a/patches/minecraft/net/minecraft/item/crafting/SmokingRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/SmokingRecipe.java.patch
@@ -20,7 +20,7 @@
 +    // CraftBukkit start
 +    @Override
 +    public Recipe toBukkitRecipe() {
-+        CraftItemStack result = CraftItemStack.asCraftMirror(this.field_222143_e);
++        CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +        CraftSmokingRecipe recipe = new CraftSmokingRecipe(CraftNamespacedKey.fromMinecraft(this.field_222140_b), result, CraftRecipe.toBukkit(this.field_222142_d), this.field_222144_f, this.field_222145_g);
 +        recipe.setGroup(this.field_222141_c);
 +        return recipe;

--- a/patches/minecraft/net/minecraft/item/crafting/StonecuttingRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/StonecuttingRecipe.java.patch
@@ -20,7 +20,7 @@
 +    // CraftBukkit start
 +    @Override
 +    public Recipe toBukkitRecipe() {
-+        CraftItemStack result = CraftItemStack.asCraftMirror(this.field_222132_b);
++        CraftItemStack result = CraftItemStack.asCraftCopy(CraftItemStack.asBukkitCopy(this.func_77571_b()));
 +        CraftStonecuttingRecipe recipe = new CraftStonecuttingRecipe(CraftNamespacedKey.fromMinecraft(this.field_222133_c), result, CraftRecipe.toBukkit(this.field_222131_a));
 +        recipe.setGroup(this.field_222134_d);
 +        return recipe;


### PR DESCRIPTION
fixes #1933
The issue here became, with kubejs recipes. That the recipe.result returned true in the ItemStack.isEmpty() call. So somehow, the recipe.result and the recipe.getResultItem() is not aligned.

When that is said, the original call inside each recipe to get the CraftItemStack was also erroring out, even when recipe.getResultItem was used. Since it never sat the type of the itemstack, but only the handle.
Hence the asBukkitCopy call, which sets the type aswell as other stuff, and then we call asCraftCopy to get it back to a type of CraftItemStack.