### PR TITLE
fix craft server createMap NPE, caused by custom map data.

### DIFF
--- a/patches/minecraft/net/minecraft/item/FilledMapItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/FilledMapItem.java.patch
@@ -24,7 +24,7 @@
 +   }
 +
 +   @Nullable
-+   protected MapData getCustomMapData(ItemStack p_195950_0_, World p_195950_1_) {
++   public static MapData getCustomMapData(ItemStack p_195950_0_, World p_195950_1_) {
        MapData mapdata = func_219994_a(p_195950_0_, p_195950_1_);
        if (mapdata == null && p_195950_1_ instanceof ServerWorld) {
           mapdata = func_195951_a(p_195950_0_, p_195950_1_, p_195950_1_.func_72912_H().func_76079_c(), p_195950_1_.func_72912_H().func_76074_e(), 3, false, false, p_195950_1_.func_234923_W_());

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/CraftServer.java
@@ -1391,7 +1391,7 @@ public final class CraftServer implements Server {
         Validate.notNull(world, "World cannot be null");
 
         net.minecraft.item.ItemStack stack = new net.minecraft.item.ItemStack(Items.MAP, 1);
-        MapData worldmap = FilledMapItem.getOrCreateSavedData(stack, ((CraftWorld) world).getHandle());
+        MapData worldmap = FilledMapItem.getCustomMapData(stack, ((CraftWorld) world).getHandle());
         return worldmap.mapView;
     }
 


### PR DESCRIPTION
Fixes https://github.com/SydMontague/ImageMaps/issues/50

Vanilla maps still work, as far as I can tell.
It was destined to always crash, since only an instanceof check was implemented for FilledMapItem, however a new ItemStack was created using the Items.Map so it would always return `null` for `CraftServer#createMap`