### PR TITLE
move up re-add cap calls, to let other events that rely on caps not crash

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -334,7 +334,7 @@
        } else {
           compoundnbt1 = this.field_72412_k.func_237336_b_(p_72380_1_);
        }
-@@ -293,187 +_,315 @@
+@@ -293,187 +_,314 @@
     }
  
     protected void func_72391_b(ServerPlayerEntity p_72391_1_) {
@@ -706,7 +706,7 @@
 +       }
 +
 +       boolean flag2 = false;
-+
++       serverplayerentity.gatherCapsAndRevive(); // Mohist - Re-gather the invalidated capabilities, since we don't create a new ServerPlayerEntity. - Moved call up, to accomodate for other event calls, where caps are maybe needed.
 +       // CraftBukkit start - fire PlayerRespawnEvent
 +       if (location == null) {
 +           boolean isBedSpawn = false;
@@ -784,7 +784,6 @@
 +       this.func_72354_b(serverplayerentity, worldserver1);
 +       this.func_187243_f(serverplayerentity);
 +       if (!p_232644_1_.field_71135_a.isDisconnected()) {
-+           serverplayerentity.gatherCapsAndRevive(); // Mohist - Re-gather the invalidated capabilities, since we don't create a new ServerPlayerEntity.
 +           worldserver1.func_217433_d(serverplayerentity);
 +           this.addPlayer(serverplayerentity);
 +           this.playersByName.put(serverplayerentity.func_195047_I_().toLowerCase(java.util.Locale.ROOT), serverplayerentity); // Spigot


### PR DESCRIPTION
Moved up the call, since some mods are relying on the caps in some events, like the XPChange event and such.