### PR TITLE
[1.12.2] Fix modded Forge generators being run in arbitrary order

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -186,7 +186,7 @@ public class GameRegistry
         long zSeed = fmlRandom.nextLong() >> 2 + 1L;
         long chunkSeed = (xSeed * chunkX + zSeed * chunkZ) ^ worldSeed;
 
-        for (IWorldGenerator generator : worldGenerators)
+        for (IWorldGenerator generator : sortedGeneratorList)
         {
             if (configWorldGenCache.get(generator.getClass().getName()))
             {


### PR DESCRIPTION
Forge's `GameRegistry` provides support for registering modded world generators to run for every chunk, as well as providing a priority index that can be given to sort which order these are generated in. This is usually handled through `GameRegistry.sortedGeneratorList`, which is recomputed whenever a new world generator entry is added: https://github.com/MohistMC/Mohist/blob/afd570fc891ff747bef914a19d1e673466b48100/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java#L199-L204

However, in the generation logic where these modded generators are invoked, unlike Forge, Mohist uses the unsorted (and arbitrarily sorted due to being a HashSet) `GameRegistry.worldGenerators`: https://github.com/MohistMC/Mohist/blob/afd570fc891ff747bef914a19d1e673466b48100/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java#L189-L196

The impact of this issue is not highly visible, but it theoretically will lead to different and unintended generation behaviour when mods are installed.

This change seems to have been introduced in https://github.com/MohistMC/Mohist/commit/4e1bbc451a3f77347cc68f44c96e50cf9cdc0acc#diff-dbdf183815d4fd33d495f4d1435585aeafc36808acc8bd52af1b69a4df4827f2R42-R43, which seems like it may have been unintentional. This PR resolves this issue by reverting the change to use `GameRegistry.worldGenerators`. 