### PR TITLE
Fix unload chunks

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -482,7 +482,7 @@
              if (this.func_175667_e(p_175653_2_))
              {
                  Chunk chunk = this.func_175726_f(p_175653_2_);
-@@ -849,6 +1081,17 @@
+@@ -849,12 +1081,24 @@
  
      public IBlockState func_180495_p(BlockPos p_180495_1_)
      {
@@ -500,7 +500,14 @@
          if (this.func_189509_E(p_180495_1_))
          {
              return Blocks.field_150350_a.func_176223_P();
-@@ -862,7 +1105,7 @@
+         }
+         else
+         {
++            if (MohistConfig.instance.preventBlockLoadChunk.getValue() && !func_175667_e(p_180495_1_)) return Blocks.field_150350_a.func_176223_P(); // CatServer
+             Chunk chunk = this.func_175726_f(p_180495_1_);
+             return chunk.func_177435_g(p_180495_1_);
+         }
+@@ -862,7 +1106,7 @@
  
      public boolean func_72935_r()
      {
@@ -509,7 +516,7 @@
      }
  
      @Nullable
-@@ -1065,6 +1308,13 @@
+@@ -1065,6 +1309,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -523,7 +530,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1112,12 +1362,68 @@
+@@ -1112,12 +1363,68 @@
  
      public boolean func_72942_c(Entity p_72942_1_)
      {
@@ -592,7 +599,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1140,31 +1446,134 @@
+@@ -1140,31 +1447,134 @@
                  this.func_72854_c();
              }
  
@@ -729,7 +736,7 @@
          if (p_72900_1_.func_184207_aI())
          {
              p_72900_1_.func_184226_ay();
-@@ -1187,11 +1596,12 @@
+@@ -1187,11 +1597,12 @@
  
      public void func_72973_f(Entity p_72973_1_)
      {
@@ -743,7 +750,7 @@
              this.field_73010_i.remove(p_72973_1_);
              this.func_72854_c();
          }
-@@ -1203,8 +1613,15 @@
+@@ -1203,8 +1614,15 @@
          {
              this.func_72964_e(i, j).func_76622_b(p_72973_1_);
          }
@@ -761,7 +768,7 @@
          this.func_72847_b(p_72973_1_);
      }
  
-@@ -1227,6 +1644,7 @@
+@@ -1227,6 +1645,7 @@
          IBlockState iblockstate = Blocks.field_150348_b.func_176223_P();
          BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
@@ -769,7 +776,7 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1269,7 +1687,7 @@
+@@ -1269,7 +1688,7 @@
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
  
@@ -778,7 +785,7 @@
                                  {
                                      boolean flag5 = true;
                                      return flag5;
-@@ -1319,11 +1737,10 @@
+@@ -1319,11 +1738,10 @@
                  }
              }
          }
@@ -791,7 +798,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1778,38 @@
+@@ -1361,19 +1779,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -832,7 +839,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1822,12 @@
+@@ -1386,6 +1823,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -845,7 +852,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1835,7 @@
+@@ -1393,9 +1836,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -856,7 +863,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1884,25 @@
+@@ -1444,20 +1885,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -885,7 +892,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1912,12 @@
+@@ -1467,6 +1913,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -898,7 +905,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1973,9 @@
+@@ -1522,9 +1974,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -910,7 +917,7 @@
              {
                  break;
              }
-@@ -1536,6 +1987,12 @@
+@@ -1536,6 +1988,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -923,7 +930,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1567,9 +2024,14 @@
+@@ -1567,9 +2025,14 @@
          for (int i = 0; i < this.field_73007_j.size(); ++i)
          {
              Entity entity = this.field_73007_j.get(i);
@@ -939,7 +946,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +2049,12 @@
+@@ -1587,6 +2050,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -952,7 +959,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1597,6 +2065,7 @@
+@@ -1597,6 +2066,7 @@
          }
  
          this.field_72984_F.func_76318_c("remove");
@@ -960,7 +967,7 @@
          this.field_72996_f.removeAll(this.field_72997_g);
  
          for (int k = 0; k < this.field_72997_g.size(); ++k)
-@@ -1618,11 +2087,19 @@
+@@ -1618,11 +2088,19 @@
  
          this.field_72997_g.clear();
          this.func_184147_l();
@@ -983,7 +990,7 @@
              Entity entity3 = entity2.func_184187_bx();
  
              if (entity3 != null)
-@@ -1641,13 +2118,23 @@
+@@ -1641,13 +2119,23 @@
              {
                  try
                  {
@@ -1007,7 +1014,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1665,34 +2152,50 @@
+@@ -1665,34 +2153,50 @@
                      this.func_72964_e(l1, i2).func_76622_b(entity2);
                  }
  
@@ -1069,7 +1076,7 @@
                  {
                      try
                      {
-@@ -1700,7 +2203,10 @@
+@@ -1700,7 +2204,10 @@
                          {
                              return String.valueOf((Object)TileEntity.func_190559_a(tileentity.getClass()));
                          });
@@ -1080,7 +1087,7 @@
                          this.field_72984_F.func_76319_b();
                      }
                      catch (Throwable throwable)
-@@ -1708,23 +2214,42 @@
+@@ -1708,23 +2215,42 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -1125,7 +1132,7 @@
          this.field_147481_N = false;
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
-@@ -1754,6 +2279,8 @@
+@@ -1754,6 +2280,8 @@
              this.field_147484_a.clear();
          }
  
@@ -1134,7 +1141,7 @@
          this.field_72984_F.func_76319_b();
          this.field_72984_F.func_76319_b();
      }
-@@ -1764,12 +2291,18 @@
+@@ -1764,12 +2292,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -1154,7 +1161,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +2318,11 @@
+@@ -1785,6 +2319,11 @@
      {
          if (this.field_147481_N)
          {
@@ -1166,7 +1173,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1803,17 +2341,32 @@
+@@ -1803,17 +2342,32 @@
  
      public void func_72866_a(Entity p_72866_1_, boolean p_72866_2_)
      {
@@ -1201,7 +1208,7 @@
  
          p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
          p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1831,7 +2384,9 @@
+@@ -1831,7 +2385,9 @@
              }
              else
              {
@@ -1211,7 +1218,7 @@
              }
          }
  
-@@ -1914,7 +2469,7 @@
+@@ -1914,7 +2470,7 @@
          {
              Entity entity4 = list.get(j2);
  
@@ -1220,7 +1227,7 @@
              {
                  return false;
              }
-@@ -1972,6 +2527,12 @@
+@@ -1972,6 +2528,12 @@
                  {
                      IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(l3, i4, j4));
  
@@ -1233,7 +1240,7 @@
                      if (iblockstate1.func_185904_a().func_76224_d())
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
-@@ -2011,6 +2572,11 @@
+@@ -2011,6 +2573,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -1245,7 +1252,7 @@
                      }
                  }
              }
-@@ -2050,6 +2616,16 @@
+@@ -2050,6 +2617,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -1262,7 +1269,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2095,7 +2671,14 @@
+@@ -2095,7 +2672,14 @@
              {
                  for (int j4 = j3; j4 < k3; ++j4)
                  {
@@ -1278,7 +1285,7 @@
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;
-@@ -2116,6 +2699,7 @@
+@@ -2116,6 +2700,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -1286,7 +1293,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2190,29 +2774,31 @@
+@@ -2190,29 +2775,31 @@
          return this.field_73020_y.func_73148_d();
      }
  
@@ -1312,8 +1319,9 @@
                  tileentity2 = this.func_189508_F(p_175625_1_);
              }
  
-             if (tileentity2 == null)
+-            if (tileentity2 == null)
 -            {
++            if (tileentity2 == null && (!MohistConfig.instance.preventBlockLoadChunk.getValue() || func_175667_e(p_175625_1_))) // CatServer add check isBlockLoaded
 +			{
                  tileentity2 = this.func_175726_f(p_175625_1_).func_177424_a(p_175625_1_, Chunk.EnumCreateEntityType.IMMEDIATE);
              }
@@ -1324,7 +1332,7 @@
                  tileentity2 = this.func_189508_F(p_175625_1_);
              }
  
-@@ -2227,7 +2813,7 @@
+@@ -2227,7 +2814,7 @@
          {
              TileEntity tileentity2 = this.field_147484_a.get(j2);
  
@@ -1333,7 +1341,7 @@
              {
                  return tileentity2;
              }
-@@ -2238,14 +2824,19 @@
+@@ -2238,14 +2825,19 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -1354,7 +1362,7 @@
  
                      while (iterator1.hasNext())
                      {
-@@ -2253,16 +2844,19 @@
+@@ -2253,16 +2845,19 @@
  
                          if (tileentity2.func_174877_v().equals(p_175690_1_))
                          {
@@ -1376,7 +1384,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2871,8 @@
+@@ -2277,6 +2872,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -1385,7 +1393,7 @@
          }
          else
          {
-@@ -2289,6 +2885,7 @@
+@@ -2289,6 +2886,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -1393,7 +1401,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2305,7 +2902,7 @@
+@@ -2305,7 +2903,7 @@
      public boolean func_175677_d(BlockPos p_175677_1_, boolean p_175677_2_)
      {
          if (this.func_189509_E(p_175677_1_))
@@ -1402,7 +1410,7 @@
              return false;
          }
          else
-@@ -2315,7 +2912,7 @@
+@@ -2315,7 +2913,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -1411,7 +1419,7 @@
              }
              else
              {
-@@ -2338,6 +2935,7 @@
+@@ -2338,6 +2936,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -1419,7 +1427,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2945,11 @@
+@@ -2347,6 +2946,11 @@
  
      protected void func_72947_a()
      {
@@ -1431,7 +1439,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2963,11 @@
+@@ -2360,6 +2964,11 @@
  
      protected void func_72979_l()
      {
@@ -1443,7 +1451,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2451,6 +3059,11 @@
+@@ -2451,6 +3060,11 @@
                  }
  
                  this.field_73004_o = MathHelper.func_76131_a(this.field_73004_o, 0.0F, 1.0F);
@@ -1455,7 +1463,7 @@
              }
          }
      }
-@@ -2484,6 +3097,11 @@
+@@ -2484,6 +3098,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -1467,7 +1475,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +3143,11 @@
+@@ -2525,6 +3144,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -1479,7 +1487,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +3165,7 @@
+@@ -2542,7 +3166,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -1488,7 +1496,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +3197,10 @@
+@@ -2574,10 +3198,10 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -1502,7 +1510,7 @@
              {
                  k2 = 1;
              }
-@@ -2589,7 +3212,7 @@
+@@ -2589,7 +3213,7 @@
  
              if (k2 >= 15)
              {
@@ -1511,7 +1519,7 @@
              }
              else if (j2 >= 14)
              {
-@@ -2630,12 +3253,16 @@
+@@ -2630,12 +3254,16 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -1529,7 +1537,7 @@
              int j2 = 0;
              int k2 = 0;
              this.field_72984_F.func_76320_a("getBrightness");
-@@ -2673,7 +3300,7 @@
+@@ -2673,7 +3301,7 @@
                              int l5 = MathHelper.func_76130_a(k4 - k3);
                              int i6 = MathHelper.func_76130_a(l4 - l3);
  
@@ -1538,7 +1546,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-@@ -2683,7 +3310,8 @@
+@@ -2683,7 +3311,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -1548,7 +1556,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2725,7 +3353,7 @@
+@@ -2725,7 +3354,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.field_72994_J.length - 6;
  
@@ -1557,7 +1565,7 @@
                          {
                              if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
                              {
-@@ -2791,10 +3419,10 @@
+@@ -2791,10 +3420,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -1572,7 +1580,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2806,19 +3434,18 @@
+@@ -2806,19 +3435,18 @@
                  }
              }
          }
@@ -1598,7 +1606,7 @@
              }
          }
  
-@@ -2847,10 +3474,10 @@
+@@ -2847,10 +3475,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -1613,7 +1621,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2863,7 +3490,6 @@
+@@ -2863,7 +3491,6 @@
                  }
              }
          }
@@ -1621,7 +1629,7 @@
          return list;
      }
  
-@@ -2919,7 +3545,16 @@
+@@ -2919,7 +3546,16 @@
  
          for (Entity entity4 : this.field_72996_f)
          {
@@ -1639,7 +1647,7 @@
              {
                  ++j2;
              }
-@@ -2930,11 +3565,19 @@
+@@ -2930,11 +3566,19 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -1662,7 +1670,7 @@
          }
      }
  
-@@ -2948,18 +3591,24 @@
+@@ -2948,18 +3592,24 @@
          IBlockState iblockstate1 = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
  
@@ -1691,7 +1699,7 @@
      }
  
      public int func_181545_F()
-@@ -3042,7 +3691,7 @@
+@@ -3042,7 +3692,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -1700,7 +1708,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3124,6 +3773,11 @@
+@@ -3124,6 +3774,11 @@
          {
              EntityPlayer entityplayer1 = this.field_73010_i.get(j2);
  
@@ -1712,7 +1720,7 @@
              if (p_190525_9_.apply(entityplayer1))
              {
                  double d1 = entityplayer1.func_70092_e(p_190525_1_, p_190525_3_, p_190525_5_);
-@@ -3141,7 +3795,7 @@
+@@ -3141,7 +3796,7 @@
  
      public boolean func_175636_b(double p_175636_1_, double p_175636_3_, double p_175636_5_, double p_175636_7_)
      {
@@ -1721,7 +1729,7 @@
          {
              EntityPlayer entityplayer = this.field_73010_i.get(j2);
  
-@@ -3156,8 +3810,8 @@
+@@ -3156,8 +3811,8 @@
              }
          }
  
@@ -1732,7 +1740,7 @@
  
      @Nullable
      public EntityPlayer func_184142_a(Entity p_184142_1_, double p_184142_2_, double p_184142_4_)
-@@ -3180,7 +3834,6 @@
+@@ -3180,7 +3835,6 @@
          for (int j2 = 0; j2 < this.field_73010_i.size(); ++j2)
          {
              EntityPlayer entityplayer1 = this.field_73010_i.get(j2);
@@ -1740,7 +1748,7 @@
              if (!entityplayer1.field_71075_bZ.field_75102_a && entityplayer1.func_70089_S() && !entityplayer1.func_175149_v() && (p_184150_12_ == null || p_184150_12_.apply(entityplayer1)))
              {
                  double d1 = entityplayer1.func_70092_e(p_184150_1_, entityplayer1.field_70163_u, p_184150_5_);
-@@ -3208,6 +3861,8 @@
+@@ -3208,6 +3862,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -1749,7 +1757,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3924,7 @@
+@@ -3269,7 +3925,7 @@
  
      public long func_72905_C()
      {
@@ -1758,7 +1766,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3934,17 @@
+@@ -3279,17 +3935,17 @@
  
      public long func_72820_D()
      {
@@ -1779,7 +1787,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3956,7 @@
+@@ -3301,7 +3957,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -1788,7 +1796,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3976,18 @@
+@@ -3321,12 +3977,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -1807,7 +1815,7 @@
          return true;
      }
  
-@@ -3363,6 +4024,16 @@
+@@ -3363,6 +4025,16 @@
      {
      }
  
@@ -1824,7 +1832,7 @@
      public float func_72819_i(float p_72819_1_)
      {
          return (this.field_73018_p + (this.field_73017_q - this.field_73018_p) * p_72819_1_) * this.func_72867_j(p_72819_1_);
-@@ -3428,8 +4099,7 @@
+@@ -3428,8 +4100,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -1834,7 +1842,7 @@
      }
  
      @Nullable
-@@ -3490,12 +4160,12 @@
+@@ -3490,12 +4161,12 @@
  
      public int func_72800_K()
      {
@@ -1849,7 +1857,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +4209,7 @@
+@@ -3539,7 +4210,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -1858,7 +1866,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +4243,7 @@
+@@ -3573,7 +4244,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -1867,7 +1875,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +4251,15 @@
+@@ -3581,18 +4252,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -1890,7 +1898,7 @@
                      }
                  }
              }
-@@ -3655,9 +4322,131 @@
+@@ -3655,9 +4323,131 @@
          int j2 = p_72916_1_ * 16 + 8 - blockpos1.func_177958_n();
          int k2 = p_72916_2_ * 16 + 8 - blockpos1.func_177952_p();
          int l2 = 128;
@@ -2023,7 +2031,7 @@
      public void func_184135_a(Packet<?> p_184135_1_)
      {
          throw new UnsupportedOperationException("Can't send packets to server unless you're on the client.");
-@@ -3673,4 +4462,11 @@
+@@ -3673,4 +4463,11 @@
      {
          return null;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkProviderServer.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkProviderServer.java
-@@ -23,9 +23,14 @@
+@@ -2,6 +2,7 @@
+ 
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Sets;
++import com.mohistmc.configuration.MohistConfig;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+ import it.unimi.dsi.fastutil.objects.ObjectIterator;
+@@ -23,9 +24,14 @@
  import net.minecraft.world.biome.Biome;
  import net.minecraft.world.chunk.Chunk;
  import net.minecraft.world.chunk.IChunkProvider;
@@ -15,7 +23,7 @@
  
  public class ChunkProviderServer implements IChunkProvider
  {
-@@ -35,6 +40,7 @@
+@@ -35,6 +41,7 @@
      public final IChunkLoader field_73247_e;
      public final Long2ObjectMap<Chunk> field_73244_f = new Long2ObjectOpenHashMap<Chunk>(8192);
      public final WorldServer field_73251_h;
@@ -23,7 +31,16 @@
  
      public ChunkProviderServer(WorldServer p_i46838_1_, IChunkLoader p_i46838_2_, IChunkGenerator p_i46838_3_)
      {
-@@ -82,43 +88,91 @@
+@@ -74,7 +81,7 @@
+         long i = ChunkPos.func_77272_a(p_186026_1_, p_186026_2_);
+         Chunk chunk = (Chunk)this.field_73244_f.get(i);
+ 
+-        if (chunk != null)
++        if (chunk != null && !MohistConfig.instance.forceUnloadChunks.getValue())
+         {
+             chunk.field_189550_d = false;
+         }
+@@ -82,43 +89,91 @@
          return chunk;
      }
  
@@ -125,7 +142,7 @@
                  crashreportcategory.func_71507_a("Position hash", Long.valueOf(i));
                  crashreportcategory.func_71507_a("Generator", this.field_186029_c);
                  throw new ReportedException(crashreport);
-@@ -126,7 +180,8 @@
+@@ -126,7 +181,8 @@
  
              this.field_73244_f.put(i, chunk);
              chunk.func_76631_c();
@@ -135,7 +152,7 @@
          }
  
          return chunk;
-@@ -168,7 +223,7 @@
+@@ -168,7 +224,7 @@
  
      private void func_73242_b(Chunk p_73242_1_)
      {
@@ -144,7 +161,7 @@
          {
              p_73242_1_.func_177432_b(this.field_73251_h.func_82737_E());
              this.field_73247_e.func_75816_a(this.field_73251_h, p_73242_1_);
-@@ -224,6 +279,11 @@
+@@ -224,6 +280,11 @@
          {
              if (!this.field_73248_b.isEmpty())
              {
@@ -156,7 +173,7 @@
                  Iterator<Long> iterator = this.field_73248_b.iterator();
  
                  for (int i = 0; i < 100 && iterator.hasNext(); iterator.remove())
-@@ -233,21 +293,56 @@
+@@ -233,21 +294,56 @@
  
                      if (chunk != null && chunk.field_189550_d)
                      {

--- a/src/main/java/com/mohistmc/configuration/MohistConfig.java
+++ b/src/main/java/com/mohistmc/configuration/MohistConfig.java
@@ -104,6 +104,9 @@ public class MohistConfig extends ConfigBase {
     // MohistProxySelector
     public final BoolSetting debug_msg = new BoolSetting(this, "mohist.networkmanager.debug", false);
 
+    public final BoolSetting preventBlockLoadChunk = new BoolSetting(this, "preventBlockLoadChunk", false); // CatServer
+    public final BoolSetting forceUnloadChunks = new BoolSetting(this, "forceUnloadChunks", false); // by Serega007
+
     private final String HEADER = "This is the main configuration file for Mohist.\n"
             + "\n"
             + "Home: https://mohistmc.com/\n";

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftServer.java
@@ -327,7 +327,7 @@ public final class CraftServer implements Server {
         ambientSpawn = configuration.getInt("spawn-limits.ambient");
         console.autosavePeriod = configuration.getInt("ticks-per.autosave");
         warningState = WarningState.value(configuration.getString("settings.deprecated-verbose"));
-        chunkGCPeriod = Math.min(20,configuration.getInt("chunk-gc.period-in-ticks"));
+        chunkGCPeriod = configuration.getInt("chunk-gc.period-in-ticks");
         chunkGCLoadThresh = configuration.getInt("chunk-gc.load-threshold");
         loadIcon();
     }
@@ -803,7 +803,7 @@ public final class CraftServer implements Server {
         warningState = WarningState.value(configuration.getString("settings.deprecated-verbose"));
         printSaveWarning = false;
         console.autosavePeriod = configuration.getInt("ticks-per.autosave");
-        chunkGCPeriod = Math.min(20, configuration.getInt("chunk-gc.period-in-ticks"));
+        chunkGCPeriod = configuration.getInt("chunk-gc.period-in-ticks");
         chunkGCLoadThresh = configuration.getInt("chunk-gc.load-threshold");
         loadIcon();
 


### PR DESCRIPTION
Sorry for my poor English, I used a translator

Hello! I noticed on my server that the chunks on which the players have established their base (they have installed many mechanisms in different chunks) are not unloaded. After studying the problem in more detail, I found that core minecraft does not even try to unload these chunks, since the chunks that should be unloaded are removed from the chunk unloading queue. They are removed from the queue because most mods try to get BlockState or just Block from a neighboring chunk if blocks from these mods are located on the border of chunks. That's when, say, the mod tries to get the BlockState of a Block from a neighboring chunk, then this chunk is removed from the chunk unloading queue and thus the chunk is always loaded.

This fix option is very questionable and therefore it is placed in the config and disabled by default. I also added some patches with CatServer that also help in solving this problem.

Testing on my server, I did not find any problems with mods or crash, but I assume that there may be problems, if I find them, I will let you know.

Also this should solve #1125

I am waiting for your comments if this correction option is not acceptable