### PR TITLE
Fixed an issue where the CraftChunkSnapshot chunk snapshot was not getting the correct mod block id

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftChunk.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftChunk.java
@@ -249,17 +249,17 @@ public class CraftChunk implements Chunk {
 
                 byte[] rawIds = new byte[4096];
                 NibbleArray data = new NibbleArray();
-                NibbleArray blockIdExtensionData = cs[i].getData().getDataForNBT(rawIds, data); // mirrol
+                NibbleArray blockIdExtensionData = cs[i].getData().getDataForNBT(rawIds, data); // Mohist
 
                 byte[] dataValues = sectionBlockData[i] = data.getData();
 
                 // Copy base IDs
                 for (int j = 0; j < 4096; j++) {
-                    // mirrol start
+                    // Mohist start
                     int extData = blockIdExtensionData == null ? 0 : blockIdExtensionData.get(j & 15, j >> 8 & 15, j >> 4 & 15);
                     int blockId = (extData << 12 | (rawIds[j] & 0xFF) << 4 | extData) >> 4;
                     blockids[j] = blockId > Short.MAX_VALUE ? 0 : (short)blockId; // Not support id > 32767
-                    // mirrol end
+                    // Mohist end
                 }
 
                 sectionBlockIDs[i] = blockids;

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftChunk.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftChunk.java
@@ -249,13 +249,17 @@ public class CraftChunk implements Chunk {
 
                 byte[] rawIds = new byte[4096];
                 NibbleArray data = new NibbleArray();
-                cs[i].getData().getDataForNBT(rawIds, data);
+                NibbleArray blockIdExtensionData = cs[i].getData().getDataForNBT(rawIds, data); // mirrol
 
                 byte[] dataValues = sectionBlockData[i] = data.getData();
 
                 // Copy base IDs
                 for (int j = 0; j < 4096; j++) {
-                    blockids[j] = (short) (rawIds[j] & 0xFF);
+                    // mirrol start
+                    int extData = blockIdExtensionData == null ? 0 : blockIdExtensionData.get(j & 15, j >> 8 & 15, j >> 4 & 15);
+                    int blockId = (extData << 12 | (rawIds[j] & 0xFF) << 4 | extData) >> 4;
+                    blockids[j] = blockId > Short.MAX_VALUE ? 0 : (short)blockId; // Not support id > 32767
+                    // mirrol end
                 }
 
                 sectionBlockIDs[i] = blockids;


### PR DESCRIPTION
When calling the chunk.getHighestBlockYAt(x, z) method from the bukkit, blocks from the mod were ignored.