### PR TITLE
Fix #2166 (remove dump fakeplayer)

### DIFF
--- a/src/main/java/com/mohistmc/command/DumpCommand.java
+++ b/src/main/java/com/mohistmc/command/DumpCommand.java
@@ -5,7 +5,6 @@ import com.mohistmc.api.ChatComponentAPI;
 import com.mohistmc.api.ItemAPI;
 import com.mohistmc.api.ServerAPI;
 import com.mohistmc.util.HasteUtils;
-import com.mojang.authlib.GameProfile;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -16,8 +15,6 @@ import java.util.Locale;
 import java.util.Map;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.util.FakePlayer;
-import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.ChatColor;
@@ -34,12 +31,12 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 
 public class DumpCommand extends Command {
-    private final List<String> tab_cmd = Arrays.asList("potions", "enchants", "cbcmds", "modscmds", "entitytypes", "biomes", "pattern", "worldgen", "worldtype", "bukkit_material", "vanilla_material", "fakeplayer");
+    private final List<String> tab_cmd = Arrays.asList("potions", "enchants", "cbcmds", "modscmds", "entitytypes", "biomes", "pattern", "worldgen", "worldtype", "bukkit_material", "vanilla_material");
     private final List<String> tab_mode = Arrays.asList("file", "web");
     public DumpCommand(String name) {
         super(name);
         this.description = "Universal Dump, which will print the information you need locally!";
-        this.usageMessage = "/dump <file|web> [potions|enchants|cbcmds|modscmds|entitytypes|biomes|pattern|worldgen|worldtype|bukkit_material|vanilla_material|fakeplayer]";
+        this.usageMessage = "/dump <file|web> [potions|enchants|cbcmds|modscmds|entitytypes|biomes|pattern|worldgen|worldtype|bukkit_material|vanilla_material]";
         this.setPermission("mohist.command.dump");
     }
 
@@ -111,8 +108,6 @@ public class DumpCommand extends Command {
                 case "vanilla_material":
                     dumpVanillaMaterial(sender, mode);
                     break;
-                case "fakeplayer":
-                    dumpFakePlayer(sender, mode);
                 default:
                     return false;
             }
@@ -225,14 +220,6 @@ public class DumpCommand extends Command {
             sb.append(material).append("\n");
         }
         dump(sender, "vanilla_material", sb, mode);
-    }
-
-    private void dumpFakePlayer(CommandSender sender, String mode) {
-        StringBuilder sb = new StringBuilder();
-        for (FakePlayer fakePlayerEntry : FakePlayer.fakePlayers) {
-            sb.append(fakePlayerEntry.getUniqueID()).append(" : ").append(fakePlayerEntry.getName()).append("\n");
-        }
-        dump(sender, "fakeplayer", sb, mode);
     }
 
     private void dumpmsg(CommandSender sender, File file, String type) {

--- a/src/main/java/net/minecraftforge/common/util/FakePlayer.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayer.java
@@ -20,8 +20,6 @@
 package net.minecraftforge.common.util;
 
 import com.mojang.authlib.GameProfile;
-import java.net.InetAddress;
-import java.util.ArrayList;
 import javax.annotation.Nullable;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -36,21 +34,13 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.FMLCommonHandler;
-import org.bukkit.Bukkit;
-import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerPreLoginEvent;
-import com.mohistmc.MohistMC;
 
 //Preliminary, simple Fake Player class
 public class FakePlayer extends EntityPlayerMP
 {
-    public static ArrayList<FakePlayer> fakePlayers = new ArrayList();
-
     public FakePlayer(WorldServer world, GameProfile name)
     {
         super(FMLCommonHandler.instance().getMinecraftServerInstance(), world, name, new PlayerInteractionManager(world));
-        fakePlayers.add(this);
     }
 
 


### PR DESCRIPTION
Since a memory leak is created due to dump fakeplayer, I decided to remove this functionality, this dump still does not work correctly for FakePlayers from EnderIO, since this mod creates a new fakeplayer every time the chunk in which the Farm Station is located is loaded and this fakeplayer is not deleted when unloading the chunk.

If you really need this functionality, let me know, I will make another Pull Request in which I will try to fix the memory leak.