### PR TITLE
update(getMaterial): Adding a normalisation for classic namespace.

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -4605,7 +4605,23 @@ public enum Material implements Keyed {
             return Bukkit.getUnsafe().fromLegacy(match);
         }
 
-        return BY_NAME.get(name);
+        return BY_NAME.get(normalize(name));
+    }
+
+    /**
+     * Attempts to normalise the input namespace 'modid:example_material'
+     * To the MohistMC format 'MODID_EXAMPLE_MATERIAL'
+     *
+     * @param namespace 'modid:example_material'
+     * @return normalized namespace
+     */
+    public static String normalize(String namespace) {
+        String normalized = namespace;
+
+        if (namespace.indexOf(':') != -1 && !namespace.startsWith("minecraft"))
+            normalized = normalized.replace(':', '_').toUpperCase();
+
+        return normalized;
     }
 
     /**


### PR DESCRIPTION
Hello there!

I have made some changes on the Material class to be able to use normal namespace aka 'modid:example_material'

This changes are kinda small but can help some people using the Material, 
I was careful to not make compatibility issue with the 'MODID_EXAMPLE_MATERIAL' format.

If any changes is needed let me know! 😺 