### PR TITLE
Fix 1.19.2 Crash "org.bukkit.block.Block.getType()" is null

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -367,8 +367,8 @@
 +               } else if (p_19974_.f_82481_ < vec3.f_82481_) {
 +                  bl = bl.getRelative(BlockFace.NORTH);
 +               }
-+
-+               if (!bl.getType().isAir()) {
++               var blType = bl.getType();
++               if (blType==null || !blType.isAir()) { // it maybe not air if the type is null
 +                  VehicleBlockCollisionEvent event = new VehicleBlockCollisionEvent(vehicle, bl);
 +                  f_19853_.getCraftServer().getPluginManager().callEvent(event);
 +               }


### PR DESCRIPTION
may help : #2874 
```
net.minecraft.ReportedException: Ticking entity
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:1087) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:327) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:1018) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:855) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:279) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.bukkit.Material.isAir()" because the return value of "org.bukkit.block.Block.getType()" is null
	at net.minecraft.world.entity.Entity.m_6478_(Entity.java:830) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.LivingEntity.m_21074_(LivingEntity.java:2457) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.LivingEntity.m_7023_(LivingEntity.java:2414) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.animal.Pig.m_7760_(Pig.java:241) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.ItemSteerable.m_20854_(ItemSteerable.java:25) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.animal.Pig.m_7023_(Pig.java:233) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.LivingEntity.m_8107_(LivingEntity.java:2853) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.Mob.m_8107_(Mob.java:570) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.AgeableMob.m_8107_(AgeableMob.java:145) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.animal.Animal.m_8107_(Animal.java:56) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.LivingEntity.m_8119_(LivingEntity.java:2556) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.entity.Mob.m_8119_(Mob.java:351) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:733) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.level.Level.m_46653_(Level.java:599) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:391) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:371) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:1083) ~[server-1.19.2-20220805.130853-srg.jar%23230!/:?]
	... 5 more
```