### PR TITLE
Add missing trim patterns added in 1.20

### DIFF
--- a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+++ b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
@@ -62,4 +62,24 @@ public interface TrimPattern extends Keyed {
      * {@link Material#SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE}.
      */
     public static final TrimPattern SPIRE = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("spire"));
+    /**
+     * {@link Material#WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE}.
+     */
+    public static final TrimPattern WAYFINDER = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("wayfinder"));
+    /**
+     * {@link Material#SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE}.
+     */
+    public static final TrimPattern SHAPER = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("shaper"));
+    /**
+     * {@link Material#SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE}.
+     */
+    public static final TrimPattern SILENCE = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("silence"));
+    /**
+     * {@link Material#RAISER_ARMOR_TRIM_SMITHING_TEMPLATE}.
+     */
+    public static final TrimPattern RAISER = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("raiser"));
+    /**
+     * {@link Material#HOST_ARMOR_TRIM_SMITHING_TEMPLATE}.
+     */
+    public static final TrimPattern HOST = Registry.TRIM_PATTERN.get(NamespacedKey.minecraft("host"));
 }


### PR DESCRIPTION
Close #3133 

Add some missing trim patterns. (HOST, SILENCE, ...)
This patch is identical to [Spigot: Trim Patterns Patch](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/657df461c253a66e3382d5dbe97bd31ce0ac1438#src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java).