### PR TITLE
update for forge 43.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=false
 bukkit_version=997de31d
 craftbukkit_version=ddc9a2dad
 spigot_version=d2eba2c8
-forge_version=47.3.11
+forge_version=43.4.0
 neoforge_version=47.1.106
 mohist_group_id=com.mohistmc
 


### PR DESCRIPTION
In this version of the project, the version of Forge 43.4.0 is being compiled, in this case the version indicated on the Forge website itself