### PR TITLE
fix: correct CraftEnchantment#isCursed

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_20_R1/enchantments/CraftEnchantment.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_20_R1/enchantments/CraftEnchantment.java
@@ -72,7 +72,7 @@ public class CraftEnchantment extends Enchantment {
 
     @Override
     public boolean isCursed() {
-        return target instanceof BindingCurseEnchantment || target instanceof VanishingCurseEnchantment;
+        return this.target.isCurse(); // Paper
     }
 
     @Override


### PR DESCRIPTION
This was a fix included in my personal fork.
Since this repo is unarchived so I decide to contribute this fix here.