### PR TITLE
fix portal not respecting the searchRadius

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/portal/PortalForcer.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/portal/PortalForcer.java.patch
@@ -47,9 +47,9 @@
        PoiManager poimanager = this.f_77648_.m_8904_();
        int i = p_192987_ ? 16 : 128;
 -      poimanager.m_27056_(this.f_77648_, p_192986_, i);
-+      int newi = searchRadius.get() == -1 ? i : searchRadius.getAndSet(-1);
++      int i = searchRadius.get() == -1 ? i : searchRadius.getAndSet(-1);
 +      // CraftBukkit end
-+      poimanager.m_27056_(this.f_77648_, p_192986_, newi);
++      poimanager.m_27056_(this.f_77648_, p_192986_, i);
        Optional<PoiRecord> optional = poimanager.m_27166_((p_230634_) -> {
           return p_230634_.m_203565_(PoiTypes.f_218064_);
        }, p_192986_, i, PoiManager.Occupancy.ANY).filter((p_192981_) -> {


### PR DESCRIPTION
portal were always searching 128 block away because one of the later function was relying on i.

This can be easily tested by creating a portal in the overworld (and its nether version), going to 128 block away (200 to be sure) and go in it, in vanilla it should create a new portal and not linked to the first portal

Directly changing i should fix the issue and bring more compatibility to mod that use mixin and capture this value

For some reason the build system wouldn't work on my system (compiler run out of memory each time) so i can't test this but i made a mod that reproduce this with mixin and it work.